### PR TITLE
feat: Add Berita management features to the admin dashboard

### DIFF
--- a/src/app/admin/berita/page.tsx
+++ b/src/app/admin/berita/page.tsx
@@ -1,0 +1,632 @@
+"use client";
+
+import {
+  useState,
+  useEffect,
+  useMemo,
+  type ChangeEvent,
+  type FormEvent,
+} from "react";
+import type { Berita, BeritaPageData } from "@/lib/types";
+import Image from "next/image";
+import { PageHeader } from "@/components/admin/page-header";
+import { ConfirmModal } from "@/components/admin/confirm-modal";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Plus,
+  Edit,
+  Trash2,
+  Save,
+  Loader2,
+  Star,
+  ChevronsLeft,
+  ChevronLeft,
+  ChevronRight,
+  ChevronsRight,
+} from "lucide-react";
+import { DataCard } from "@/components/admin/data-card";
+import { SuccessModal } from "@/components/admin/success-modal";
+
+const BeritaFormModal = ({
+  isOpen,
+  onClose,
+  onSubmit,
+  berita,
+  setBerita,
+  setImageFile,
+  isSaving,
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (e: FormEvent) => void;
+  berita: Partial<Berita>;
+  setBerita: (data: Partial<Berita>) => void;
+  imageFile: File | null;
+  setImageFile: (file: File | null) => void;
+  isSaving: boolean;
+}) => {
+  const handleChange = (
+    e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    const { name, value } = e.target;
+    setBerita({ ...berita, [name]: value });
+  };
+
+  const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files && e.target.files[0]) {
+      setImageFile(e.target.files[0]);
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="sm:max-w-lg max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>
+            {berita.id ? "Edit Berita" : "Tambah Berita Baru"}
+          </DialogTitle>
+        </DialogHeader>
+        <form onSubmit={onSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="title">Judul Berita</Label>
+            <Input
+              id="title"
+              name="title"
+              value={berita.title || ""}
+              onChange={handleChange}
+              required
+              disabled={isSaving}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="content">Isi Berita</Label>
+            <Textarea
+              id="content"
+              name="content"
+              value={berita.content || ""}
+              onChange={handleChange}
+              rows={8}
+              required
+              disabled={isSaving}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="imageFile">Gambar Berita</Label>
+            {berita.id && berita.imageUrl && (
+              <div className="mb-2">
+                <p className="text-sm text-muted-foreground mb-2">
+                  Gambar saat ini:
+                </p>
+                <Image
+                  src={berita.imageUrl || "/placeholder.svg"}
+                  alt={berita.title || "Gambar saat ini"}
+                  width={120}
+                  height={80}
+                  className="rounded-md object-cover border"
+                />
+              </div>
+            )}
+            <Input
+              id="imageFile"
+              name="imageFile"
+              type="file"
+              onChange={handleFileChange}
+              accept="image/png, image/jpeg, image/jpg"
+              required={!berita.id}
+              disabled={isSaving}
+            />
+            <p className="text-sm text-muted-foreground">
+              {berita.id
+                ? "Unggah file baru untuk mengganti gambar."
+                : "File gambar wajib diunggah."}
+            </p>
+          </div>
+          <div className="flex justify-end gap-2 pt-4">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={onClose}
+              disabled={isSaving}
+            >
+              Batal
+            </Button>
+            <Button type="submit" disabled={isSaving}>
+              {isSaving ? (
+                <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+              ) : (
+                <Save className="h-4 w-4 mr-2" />
+              )}
+              {isSaving ? "Menyimpan..." : "Simpan"}
+            </Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default function ManageBeritaPage() {
+  const [beritaList, setBeritaList] = useState<Berita[]>([]);
+  const [pageData, setPageData] = useState<Partial<BeritaPageData>>({});
+  const [heroImageFile, setHeroImageFile] = useState<File | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [editingBerita, setEditingBerita] = useState<Partial<Berita>>({});
+  const [imageFile, setImageFile] = useState<File | null>(null);
+  const [confirmAction, setConfirmAction] = useState<{
+    action: () => void;
+    message: string;
+  } | null>(null);
+  const [isSavingPage, setIsSavingPage] = useState(false);
+  const [isModalSaving, setIsModalSaving] = useState(false);
+  const [showSuccessModal, setShowSuccessModal] = useState(false);
+  const [successMessage, setSuccessMessage] = useState("");
+
+  const [startDate, setStartDate] = useState("");
+  const [endDate, setEndDate] = useState("");
+  const [currentPage, setCurrentPage] = useState(1);
+  const [itemsPerPage, setItemsPerPage] = useState(10);
+
+  const fetchAllData = async () => {
+    setIsLoading(true);
+    try {
+      const [beritaRes, pageRes] = await Promise.all([
+        fetch("/api/berita"),
+        fetch("/api/berita-page"),
+      ]);
+      setBeritaList(await beritaRes.json());
+      setPageData(await pageRes.json());
+    } catch (error) {
+      console.error("Gagal mengambil data:", error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchAllData();
+  }, []);
+
+  const filteredBerita = useMemo(() => {
+    return beritaList.filter((berita) => {
+      const createdAt = new Date(berita.createdAt);
+      const start = startDate ? new Date(startDate) : null;
+      const end = endDate ? new Date(endDate) : null;
+
+      if (start) {
+        start.setHours(0, 0, 0, 0);
+        if (createdAt < start) return false;
+      }
+      if (end) {
+        end.setHours(23, 59, 59, 999);
+        if (createdAt > end) return false;
+      }
+      return true;
+    });
+  }, [beritaList, startDate, endDate]);
+
+  const paginatedBerita = useMemo(() => {
+    const startIndex = (currentPage - 1) * itemsPerPage;
+    return filteredBerita.slice(startIndex, startIndex + itemsPerPage);
+  }, [filteredBerita, currentPage, itemsPerPage]);
+
+  const totalPages = Math.ceil(filteredBerita.length / itemsPerPage);
+
+  const handleOpenModal = (berita?: Berita) => {
+    setEditingBerita(berita || {});
+    setImageFile(null);
+    setIsModalOpen(true);
+  };
+
+  const handleCloseModal = () => {
+    setIsModalOpen(false);
+    setEditingBerita({});
+  };
+
+  const handleDelete = (id: string) => {
+    setConfirmAction({
+      message: "Yakin ingin menghapus berita ini?",
+      action: async () => {
+        await fetch("/api/berita", {
+          method: "DELETE",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ id }),
+        });
+        setConfirmAction(null);
+        fetchAllData();
+        setSuccessMessage("Berita berhasil dihapus!");
+        setShowSuccessModal(true);
+      },
+    });
+  };
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setIsModalSaving(true);
+    try {
+      const formData = new FormData();
+      formData.append("title", editingBerita.title || "");
+      formData.append("content", editingBerita.content || "");
+
+      if (editingBerita.id) {
+        formData.append("id", editingBerita.id);
+      }
+      if (imageFile) {
+        formData.append("imageFile", imageFile);
+      }
+
+      const method = editingBerita.id ? "PUT" : "POST";
+      const response = await fetch("/api/berita", {
+        method,
+        body: formData,
+      });
+
+      if (response.ok) {
+        handleCloseModal();
+        fetchAllData();
+        setSuccessMessage("Berita berhasil disimpan!");
+        setShowSuccessModal(true);
+      } else {
+        const errorData = await response.json();
+        alert(`Gagal menyimpan data: ${errorData.error}`);
+      }
+    } catch (error) {
+      console.error("Gagal submit:", error);
+    } finally {
+      setIsModalSaving(false);
+    }
+  };
+
+  const handleSetHeadline = async (id: string) => {
+    try {
+      const response = await fetch("/api/berita", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id }),
+      });
+      if (response.ok) {
+        fetchAllData();
+        setSuccessMessage("Berita utama berhasil diperbarui!");
+        setShowSuccessModal(true);
+      } else {
+        alert("Gagal mengatur berita utama.");
+      }
+    } catch (error) {
+      console.error("Gagal mengatur berita utama:", error);
+    }
+  };
+
+  const handleSavePageData = async () => {
+    setIsSavingPage(true);
+    const formData = new FormData();
+
+    const jsonData = {
+      hero: pageData.hero,
+    };
+
+    formData.append("jsonData", JSON.stringify(jsonData));
+
+    if (heroImageFile) {
+      formData.append("heroImageFile", heroImageFile);
+    }
+
+    try {
+      const response = await fetch("/api/berita-page", {
+        method: "POST",
+        body: formData,
+      });
+      if (response.ok) {
+        setSuccessMessage("Konten Halaman Berita Berhasil Disimpan!");
+        setShowSuccessModal(true);
+        setHeroImageFile(null);
+        fetchAllData();
+      } else {
+        alert("Gagal menyimpan data halaman.");
+      }
+    } catch (error) {
+      console.error("Gagal menyimpan data halaman:", error);
+    } finally {
+      setIsSavingPage(false);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-[400px]">
+        <Loader2 className="h-8 w-8 animate-spin" />
+        <span className="ml-2">Memuat data berita...</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-8">
+      <SuccessModal
+        isOpen={showSuccessModal}
+        onClose={() => setShowSuccessModal(false)}
+        message={successMessage}
+      />
+      <ConfirmModal
+        isOpen={!!confirmAction}
+        onConfirm={confirmAction?.action || (() => {})}
+        onCancel={() => setConfirmAction(null)}
+        message={confirmAction?.message || ""}
+      />
+
+      <BeritaFormModal
+        isOpen={isModalOpen}
+        onClose={handleCloseModal}
+        onSubmit={handleSubmit}
+        berita={editingBerita}
+        setBerita={setEditingBerita}
+        imageFile={imageFile}
+        setImageFile={setImageFile}
+        isSaving={isModalSaving}
+      />
+
+      <PageHeader
+        title="Kelola Berita"
+        description="Atur konten halaman dan daftar berita terbaru desa"
+      />
+
+      <DataCard title="Konten Halaman Berita">
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="hero-title">Judul Hero</Label>
+            <Input
+              id="hero-title"
+              value={pageData.hero?.title || ""}
+              onChange={(e) =>
+                setPageData((prev) => ({
+                  ...prev,
+                  hero: {
+                    ...prev.hero,
+                    title: e.target.value,
+                  } as BeritaPageData["hero"],
+                }))
+              }
+              disabled={isSavingPage}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="hero-subtitle">Subjudul Hero</Label>
+            <Textarea
+              id="hero-subtitle"
+              value={pageData.hero?.subtitle || ""}
+              onChange={(e) =>
+                setPageData((prev) => ({
+                  ...prev,
+                  hero: {
+                    ...prev.hero,
+                    subtitle: e.target.value,
+                  } as BeritaPageData["hero"],
+                }))
+              }
+              rows={3}
+              disabled={isSavingPage}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="hero-image">Gambar Hero</Label>
+            {pageData.hero?.heroImage && (
+              <div className="mb-2">
+                <p className="text-sm text-muted-foreground mb-2">
+                  Gambar saat ini:
+                </p>
+                <Image
+                  src={pageData.hero.heroImage}
+                  alt="Preview Hero"
+                  width={200}
+                  height={112}
+                  className="rounded-md object-cover border"
+                />
+              </div>
+            )}
+            <Input
+              id="hero-image"
+              type="file"
+              onChange={(e) => setHeroImageFile(e.target.files?.[0] || null)}
+              accept="image/png, image/jpeg, image/jpg"
+              disabled={isSavingPage}
+            />
+            <p className="text-sm text-muted-foreground">
+              Unggah file baru untuk mengganti gambar hero.
+            </p>
+          </div>
+          <div className="flex justify-end">
+            <Button onClick={handleSavePageData} disabled={isSavingPage}>
+              {isSavingPage ? (
+                <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+              ) : (
+                <Save className="h-4 w-4 mr-2" />
+              )}
+              {isSavingPage ? "Menyimpan..." : "Simpan Konten Halaman"}
+            </Button>
+          </div>
+        </div>
+      </DataCard>
+
+      <DataCard title="Daftar Artikel Berita">
+        <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4 mb-4">
+          <div className="flex flex-col sm:flex-row gap-2">
+            <div>
+              <Label htmlFor="start-date" className="text-xs">
+                Dari Tanggal
+              </Label>
+              <Input
+                id="start-date"
+                type="date"
+                value={startDate}
+                onChange={(e) => {
+                  setStartDate(e.target.value);
+                  setCurrentPage(1);
+                }}
+              />
+            </div>
+            <div>
+              <Label htmlFor="end-date" className="text-xs">
+                Sampai Tanggal
+              </Label>
+              <Input
+                id="end-date"
+                type="date"
+                value={endDate}
+                onChange={(e) => {
+                  setEndDate(e.target.value);
+                  setCurrentPage(1);
+                }}
+              />
+            </div>
+          </div>
+          <Button onClick={() => handleOpenModal()}>
+            <Plus className="h-4 w-4 mr-2" />
+            Tambah Berita Baru
+          </Button>
+        </div>
+        <div className="border rounded-lg mt-4">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-[40px]">Utama</TableHead>
+                <TableHead>Judul</TableHead>
+                <TableHead>Tanggal Publikasi</TableHead>
+                <TableHead className="w-[100px]">Aksi</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {paginatedBerita.map((berita) => (
+                <TableRow key={berita.id}>
+                  <TableCell>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => handleSetHeadline(berita.id)}
+                    >
+                      <Star
+                        className={`h-5 w-5 ${
+                          berita.isHeadline
+                            ? "text-yellow-500 fill-yellow-400"
+                            : "text-gray-400"
+                        }`}
+                      />
+                    </Button>
+                  </TableCell>
+                  <TableCell className="font-medium">{berita.title}</TableCell>
+                  <TableCell>
+                    {new Date(berita.createdAt).toLocaleDateString("id-ID", {
+                      year: "numeric",
+                      month: "long",
+                      day: "numeric",
+                    })}
+                  </TableCell>
+                  <TableCell>
+                    <div className="flex gap-2">
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => handleOpenModal(berita)}
+                      >
+                        <Edit className="h-4 w-4" />
+                      </Button>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => handleDelete(berita.id!)}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </div>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+          {paginatedBerita.length === 0 && (
+            <div className="text-center py-8 text-muted-foreground">
+              {`Tidak ada data berita yang cocok dengan filter.`}
+            </div>
+          )}
+        </div>
+        <div className="flex flex-col sm:flex-row justify-between items-center gap-4 mt-4">
+          <Select
+            value={itemsPerPage.toString()}
+            onValueChange={(value) => {
+              setItemsPerPage(Number(value));
+              setCurrentPage(1);
+            }}
+          >
+            <SelectTrigger className="w-[180px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="10">10 per halaman</SelectItem>
+              <SelectItem value="50">50 per halaman</SelectItem>
+              <SelectItem value="100">100 per halaman</SelectItem>
+            </SelectContent>
+          </Select>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="icon"
+              onClick={() => setCurrentPage(1)}
+              disabled={currentPage === 1}
+            >
+              <ChevronsLeft className="h-4 w-4" />
+            </Button>
+            <Button
+              variant="outline"
+              size="icon"
+              onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
+              disabled={currentPage === 1}
+            >
+              <ChevronLeft className="h-4 w-4" />
+            </Button>
+            <span className="text-sm">
+              Halaman {currentPage} dari {totalPages || 1}
+            </span>
+            <Button
+              variant="outline"
+              size="icon"
+              onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))}
+              disabled={currentPage === totalPages}
+            >
+              <ChevronRight className="h-4 w-4" />
+            </Button>
+            <Button
+              variant="outline"
+              size="icon"
+              onClick={() => setCurrentPage(totalPages)}
+              disabled={currentPage === totalPages}
+            >
+              <ChevronsRight className="h-4 w-4" />
+            </Button>
+          </div>
+        </div>
+      </DataCard>
+    </div>
+  );
+}

--- a/src/app/admin/dashboard/page.tsx
+++ b/src/app/admin/dashboard/page.tsx
@@ -17,6 +17,7 @@ import {
   FileText,
   MapPin,
   Phone,
+  Newspaper,
 } from "lucide-react";
 import Link from "next/link";
 
@@ -62,6 +63,12 @@ export default async function DashboardPage() {
       description: "Formulir dan pelayanan desa",
       icon: FileText,
       href: "/admin/layanan",
+    },
+    {
+      title: "Berita",
+      description: "Kelola berita dan informasi terbaru",
+      icon: Newspaper, // Tambahkan item baru
+      href: "/admin/berita",
     },
     {
       title: "Kontak",

--- a/src/app/api/berita-page/route.ts
+++ b/src/app/api/berita-page/route.ts
@@ -1,0 +1,93 @@
+// src/app/api/berita-page/route.ts
+
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { db } from '@/lib/firebase';
+import { doc, getDoc, setDoc, DocumentData } from 'firebase/firestore';
+import { BeritaPageData } from '@/lib/types';
+import { v2 as cloudinary } from 'cloudinary';
+
+// Konfigurasi Cloudinary
+cloudinary.config({
+  cloud_name: process.env.NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME,
+  api_key: process.env.CLOUDINARY_API_KEY,
+  api_secret: process.env.CLOUDINARY_API_SECRET
+});
+
+const COLLECTION_NAME = "konten-halaman";
+const DOCUMENT_ID = "berita";
+
+const defaultData: BeritaPageData = {
+    hero: {
+        title: "BERITA DESA",
+        subtitle: "Informasi terkini seputar kegiatan dan perkembangan Desa Slamparejo.",
+        heroImage: "/landing-page.png"
+    }
+};
+
+async function isAuthorized() {
+    const session = await getServerSession(authOptions);
+    return !!session;
+}
+
+async function handleFileUpload(file: File | null): Promise<string | null> {
+    if (!file) return null;
+    const bytes = await file.arrayBuffer();
+    const buffer = Buffer.from(bytes);
+    return new Promise((resolve, reject) => {
+        const uploadStream = cloudinary.uploader.upload_stream(
+            { folder: 'desa-slamparejo-uploads' },
+            (error, result) => {
+                if (error) reject(error);
+                resolve(result?.secure_url || null);
+            }
+        );
+        uploadStream.end(buffer);
+    });
+}
+
+export async function GET() {
+  try {
+    const docRef = doc(db, COLLECTION_NAME, DOCUMENT_ID);
+    const docSnap = await getDoc(docRef);
+
+    if (docSnap.exists()) {
+      return NextResponse.json(docSnap.data() as BeritaPageData);
+    } else {
+      await setDoc(docRef, defaultData as DocumentData);
+      return NextResponse.json(defaultData);
+    }
+  } catch (error) {
+    console.error("Firebase GET Error:", error);
+    return NextResponse.json({ error: 'Gagal mengambil data halaman berita' }, { status: 500 });
+  }
+}
+
+export async function POST(request: Request) {
+    if (!await isAuthorized()) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    try {
+        const formData = await request.formData();
+        const heroImageFile = formData.get('heroImageFile') as File | null;
+        const newHeroImageUrl = await handleFileUpload(heroImageFile);
+
+        const jsonDataString = formData.get('jsonData') as string;
+        if (!jsonDataString) {
+             return NextResponse.json({ error: 'Data JSON tidak ditemukan' }, { status: 400 });
+        }
+        const dataToSave: BeritaPageData = JSON.parse(jsonDataString);
+        
+        if (newHeroImageUrl) {
+            dataToSave.hero.heroImage = newHeroImageUrl;
+        }
+
+        const docRef = doc(db, COLLECTION_NAME, DOCUMENT_ID);
+        await setDoc(docRef, dataToSave as DocumentData, { merge: true });
+        return NextResponse.json({ message: 'Data halaman berita berhasil disimpan' }, { status: 200 });
+    } catch (error) {
+        console.error("Firebase POST Error:", error);
+        return NextResponse.json({ error: 'Gagal menyimpan data halaman berita' }, { status: 500 });
+    }
+}

--- a/src/app/api/berita/route.ts
+++ b/src/app/api/berita/route.ts
@@ -1,0 +1,177 @@
+// src/app/api/berita/route.ts
+
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { db } from '@/lib/firebase';
+import { collection, getDocs, addDoc, doc, updateDoc, deleteDoc, query, orderBy, getDoc, writeBatch } from 'firebase/firestore';
+import { Berita } from '@/lib/types';
+import { v2 as cloudinary } from 'cloudinary';
+
+// Konfigurasi Cloudinary
+cloudinary.config({
+  cloud_name: process.env.NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME,
+  api_key: process.env.CLOUDINARY_API_KEY,
+  api_secret: process.env.CLOUDINARY_API_SECRET
+});
+
+const COLLECTION_NAME = "berita";
+
+async function isAuthorized() {
+    const session = await getServerSession(authOptions);
+    return !!session;
+}
+
+// Fungsi helper untuk unggah file ke Cloudinary
+async function handleFileUpload(file: File | null): Promise<string | null> {
+    if (!file) return null;
+
+    const bytes = await file.arrayBuffer();
+    const buffer = Buffer.from(bytes);
+
+    return new Promise((resolve, reject) => {
+        const uploadStream = cloudinary.uploader.upload_stream(
+            {
+                folder: 'desa-slamparejo-berita',
+            },
+            (error, result) => {
+                if (error) {
+                    reject(error);
+                }
+                resolve(result?.secure_url || null);
+            }
+        );
+        uploadStream.end(buffer);
+    });
+}
+
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const id = searchParams.get('id');
+
+    if (id) {
+      const docRef = doc(db, COLLECTION_NAME, id);
+      const docSnap = await getDoc(docRef);
+      if (docSnap.exists()) {
+        return NextResponse.json({ id: docSnap.id, ...docSnap.data() });
+      } else {
+        return NextResponse.json({ error: 'Berita tidak ditemukan' }, { status: 404 });
+      }
+    } else {
+      const q = query(collection(db, COLLECTION_NAME), orderBy("createdAt", "desc"));
+      const data = await getDocs(q);
+      const beritaData = data.docs.map((doc) => ({ ...(doc.data() as Omit<Berita, 'id'>), id: doc.id }));
+      
+      // Logika untuk memindahkan berita utama ke atas
+      beritaData.sort((a, b) => {
+        if (a.isHeadline && !b.isHeadline) return -1;
+        if (!a.isHeadline && b.isHeadline) return 1;
+        return 0; // Urutan lainnya tetap berdasarkan tanggal
+      });
+
+      return NextResponse.json(beritaData);
+    }
+  } catch (error) {
+    console.error("Firebase GET Error:", error);
+    return NextResponse.json({ error: 'Failed to fetch data' }, { status: 500 });
+  }
+}
+
+export async function POST(request: Request) {
+    if (!await isAuthorized()) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    try {
+        const formData = await request.formData();
+        const file = formData.get('imageFile') as File | null;
+        const imageUrl = await handleFileUpload(file);
+
+        if (!imageUrl) {
+            return NextResponse.json({ error: 'File gambar diperlukan' }, { status: 400 });
+        }
+
+        const newData: Omit<Berita, 'id' | 'imageUrl'> = {
+            title: formData.get('title') as string,
+            content: formData.get('content') as string,
+            createdAt: Date.now(),
+        };
+
+        const docRef = await addDoc(collection(db, COLLECTION_NAME), { ...newData, imageUrl });
+        return NextResponse.json({ ...newData, imageUrl, id: docRef.id }, { status: 201 });
+    } catch (error) {
+        console.error("Firebase POST Error:", error);
+        return NextResponse.json({ error: 'Failed to create data' }, { status: 500 });
+    }
+}
+
+export async function PUT(request: Request) {
+    if (!await isAuthorized()) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    try {
+        const formData = await request.formData();
+        const id = formData.get('id') as string;
+        if (!id) return NextResponse.json({ error: 'ID is required' }, { status: 400 });
+
+        const file = formData.get('imageFile') as File | null;
+        const imageUrl = await handleFileUpload(file);
+
+        const dataToUpdate: Partial<Omit<Berita, 'id' | 'imageUrl'>> = {
+            title: formData.get('title') as string,
+            content: formData.get('content') as string,
+        };
+
+        const finalData = { ...dataToUpdate, ...(imageUrl && { imageUrl }) };
+
+        const beritaDoc = doc(db, COLLECTION_NAME, id);
+        await updateDoc(beritaDoc, finalData);
+        return NextResponse.json({ id, ...finalData });
+    } catch (error) {
+        console.error("Firebase PUT Error:", error);
+        return NextResponse.json({ error: 'Failed to update data' }, { status: 500 });
+    }
+}
+
+export async function DELETE(request: Request) {
+    if (!await isAuthorized()) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    try {
+        const { id }: { id: string } = await request.json();
+        if (!id) return NextResponse.json({ error: 'ID is required' }, { status: 400 });
+        
+        const beritaDoc = doc(db, COLLECTION_NAME, id);
+        await deleteDoc(beritaDoc);
+        return NextResponse.json({ message: 'Data deleted successfully' });
+    } catch (error) {
+        console.error("Firebase DELETE Error:", error);
+        return NextResponse.json({ error: 'Failed to delete data' }, { status: 500 });
+    }
+}
+
+export async function PATCH(request: Request) {
+    if (!await isAuthorized()) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    try {
+        const { id: newHeadlineId }: { id: string } = await request.json();
+        if (!newHeadlineId) return NextResponse.json({ error: 'ID is required' }, { status: 400 });
+
+        const batch = writeBatch(db);
+        const beritaCollection = collection(db, COLLECTION_NAME);
+        
+        // 1. Unset all other headlines
+        const q = query(beritaCollection);
+        const snapshot = await getDocs(q);
+        snapshot.forEach((document) => {
+            if (document.id !== newHeadlineId) {
+                batch.update(document.ref, { isHeadline: false });
+            }
+        });
+
+        // 2. Set the new headline
+        const newHeadlineRef = doc(db, COLLECTION_NAME, newHeadlineId);
+        batch.update(newHeadlineRef, { isHeadline: true });
+
+        // Commit the batch
+        await batch.commit();
+
+        return NextResponse.json({ message: 'Headline updated successfully' });
+    } catch (error) {
+        console.error("Firebase PATCH Error:", error);
+        return NextResponse.json({ error: 'Failed to update headline' }, { status: 500 });
+    }
+}

--- a/src/app/berita/[id]/page.tsx
+++ b/src/app/berita/[id]/page.tsx
@@ -1,5 +1,3 @@
-// src/app/berita/[id]/page.tsx
-
 import { Berita } from "@/lib/types";
 import Image from "next/image";
 import { Playfair_Display, Poppins } from "next/font/google";
@@ -14,7 +12,7 @@ const poppins = Poppins({
   weight: ["400", "600"],
 });
 
-async function getBeritaDetail(id: any): Promise<Berita | null> {
+async function getBeritaDetail(id: string): Promise<Berita | null> {
   try {
     const res = await fetch(`${process.env.NEXTAUTH_URL}/api/berita?id=${id}`, {
       cache: "no-store",
@@ -27,12 +25,21 @@ async function getBeritaDetail(id: any): Promise<Berita | null> {
   }
 }
 
+// Definisikan tipe untuk props halaman secara eksplisit
+type BeritaDetailPageProps = {
+  params: {
+    id: string;
+  };
+};
+
 export default async function BeritaDetailPage({
   params,
-}: {
-  params: { id: string };
-}) {
-  const berita = await getBeritaDetail(params.id);
+}: BeritaDetailPageProps) {
+  // Ambil id dari params (objek biasa, bukan promise)
+  const { id } = params;
+
+  // Gunakan id untuk mengambil data berita
+  const berita = await getBeritaDetail(id);
 
   if (!berita) {
     return (

--- a/src/app/berita/[id]/page.tsx
+++ b/src/app/berita/[id]/page.tsx
@@ -14,7 +14,7 @@ const poppins = Poppins({
   weight: ["400", "600"],
 });
 
-async function getBeritaDetail(id: string): Promise<Berita | null> {
+async function getBeritaDetail(id: any): Promise<Berita | null> {
   try {
     const res = await fetch(`${process.env.NEXTAUTH_URL}/api/berita?id=${id}`, {
       cache: "no-store",

--- a/src/app/berita/[id]/page.tsx
+++ b/src/app/berita/[id]/page.tsx
@@ -25,18 +25,18 @@ async function getBeritaDetail(id: string): Promise<Berita | null> {
   }
 }
 
-// Definisikan tipe untuk props halaman secara eksplisit
+// Definisikan tipe untuk props halaman, dengan params sebagai Promise
 type BeritaDetailPageProps = {
-  params: {
+  params: Promise<{
     id: string;
-  };
+  }>;
 };
 
 export default async function BeritaDetailPage({
   params,
 }: BeritaDetailPageProps) {
-  // Ambil id dari params (objek biasa, bukan promise)
-  const { id } = params;
+  // Gunakan await untuk mendapatkan nilai dari promise params
+  const { id } = await params;
 
   // Gunakan id untuk mengambil data berita
   const berita = await getBeritaDetail(id);

--- a/src/app/berita/[id]/page.tsx
+++ b/src/app/berita/[id]/page.tsx
@@ -1,0 +1,74 @@
+// src/app/berita/[id]/page.tsx
+
+import { Berita } from "@/lib/types";
+import Image from "next/image";
+import { Playfair_Display, Poppins } from "next/font/google";
+
+const playfair = Playfair_Display({
+  subsets: ["latin"],
+  weight: ["400", "700"],
+});
+
+const poppins = Poppins({
+  subsets: ["latin"],
+  weight: ["400", "600"],
+});
+
+async function getBeritaDetail(id: string): Promise<Berita | null> {
+  try {
+    const res = await fetch(`${process.env.NEXTAUTH_URL}/api/berita?id=${id}`, {
+      cache: "no-store",
+    });
+    if (!res.ok) return null;
+    return res.json();
+  } catch (error) {
+    console.error("Gagal mengambil detail berita:", error);
+    return null;
+  }
+}
+
+export default async function BeritaDetailPage({
+  params,
+}: {
+  params: { id: string };
+}) {
+  const berita = await getBeritaDetail(params.id);
+
+  if (!berita) {
+    return (
+      <div className="flex items-center justify-center h-screen">
+        Gagal memuat berita atau berita tidak ditemukan.
+      </div>
+    );
+  }
+
+  return (
+    <main className="min-h-screen bg-white pt-24">
+      <div className="max-w-4xl mx-auto px-4 py-8">
+        <h1 className={`${playfair.className} text-4xl font-bold mb-4`}>
+          {berita.title}
+        </h1>
+        <p className={`${poppins.className} text-gray-500 mb-6`}>
+          {new Date(berita.createdAt).toLocaleDateString("id-ID", {
+            year: "numeric",
+            month: "long",
+            day: "numeric",
+          })}
+        </p>
+        <div className="relative w-full h-96 mb-8 rounded-lg overflow-hidden">
+          <Image
+            src={berita.imageUrl}
+            alt={berita.title}
+            layout="fill"
+            objectFit="cover"
+          />
+        </div>
+        <div
+          className={`${poppins.className} text-lg leading-relaxed text-gray-800 whitespace-pre-line`}
+        >
+          {berita.content}
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/berita/page.tsx
+++ b/src/app/berita/page.tsx
@@ -1,0 +1,49 @@
+// src/app/berita/page.tsx
+
+import { Berita, BeritaPageData } from "@/lib/types";
+import HeroBerita from "@/features/berita/hero";
+import DaftarBerita from "@/features/berita/berita";
+import DescBerita from "@/features/berita/desc";
+
+async function getPageData(): Promise<{
+  beritaList: Berita[];
+  pageData: BeritaPageData;
+} | null> {
+  try {
+    const [beritaRes, pageRes] = await Promise.all([
+      fetch(`${process.env.NEXTAUTH_URL}/api/berita`, { cache: "no-store" }),
+      fetch(`${process.env.NEXTAUTH_URL}/api/berita-page`, {
+        cache: "no-store",
+      }),
+    ]);
+    if (!beritaRes.ok || !pageRes.ok) return null;
+
+    const beritaList = await beritaRes.json();
+    const pageData = await pageRes.json();
+
+    return { beritaList, pageData };
+  } catch (error) {
+    console.error("Gagal mengambil data berita:", error);
+    return null;
+  }
+}
+
+export default async function BeritaPage() {
+  const data = await getPageData();
+
+  if (!data) {
+    return (
+      <div className="flex items-center justify-center h-screen">
+        Gagal memuat data.
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <HeroBerita data={data.pageData.hero} />
+      <DescBerita />
+      <DaftarBerita dataBerita={data.beritaList} />
+    </>
+  );
+}

--- a/src/components/admin/app-sidebar.tsx
+++ b/src/components/admin/app-sidebar.tsx
@@ -22,6 +22,7 @@ import {
   Settings,
   LogOut,
   MapPin,
+  Newspaper,
 } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
@@ -63,6 +64,11 @@ const menuItems = [
     title: "Layanan",
     url: "/admin/layanan",
     icon: FileText,
+  },
+  {
+    title: "Berita",
+    url: "/admin/berita",
+    icon: Newspaper,
   },
   {
     title: "Kontak",

--- a/src/features/berita/berita.tsx
+++ b/src/features/berita/berita.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { useState } from "react";
+import Card from "./card";
+import { Berita } from "@/lib/types";
+import Image from "next/image";
+import Link from "next/link";
+import { Poppins } from "next/font/google";
+
+const poppins = Poppins({
+  subsets: ["latin"],
+  weight: ["400", "600"],
+});
+
+const ITEMS_PER_PAGE = 9; // 1 Utama + 8 Lainnya
+
+export default function DaftarBerita({ dataBerita }: { dataBerita: Berita[] }) {
+  const [currentPage, setCurrentPage] = useState(1);
+
+  // Pisahkan berita utama dari daftar
+  const headline = dataBerita.find((b) => b.isHeadline);
+  const otherNews = dataBerita.filter((b) => !b.isHeadline);
+
+  // Jika tidak ada headline, gunakan berita terbaru sebagai fallback
+  const mainNewsSource = headline
+    ? [headline, ...otherNews.filter((b) => b.id !== headline.id)]
+    : dataBerita;
+
+  if (!mainNewsSource || mainNewsSource.length === 0) {
+    return (
+      <div className="text-center py-10 bg-[#f4f8fc]">
+        Belum ada data berita yang tersedia.
+      </div>
+    );
+  }
+
+  const totalPages = Math.ceil(mainNewsSource.length / ITEMS_PER_PAGE);
+  const startIndex = (currentPage - 1) * ITEMS_PER_PAGE;
+  const endIndex = startIndex + ITEMS_PER_PAGE;
+  const currentBerita = mainNewsSource.slice(startIndex, endIndex);
+
+  const beritaUtama = currentBerita[0];
+  const beritaLainnya = currentBerita.slice(1);
+
+  const handlePageChange = (page: number) => {
+    if (page >= 1 && page <= totalPages) {
+      setCurrentPage(page);
+    }
+  };
+
+  return (
+    <section className="bg-[#f4f8fc] px-4 py-10">
+      <div className="max-w-6xl mx-auto">
+        {/* Berita Utama */}
+        {beritaUtama && (
+          <div className="mb-12">
+            <div className="bg-white rounded-xl shadow-lg overflow-hidden flex flex-col md:flex-row min-h-[400px]">
+              <div className="relative w-full md:w-1/2 h-64 md:h-auto">
+                <Image
+                  src={beritaUtama.imageUrl}
+                  alt={beritaUtama.title}
+                  layout="fill"
+                  objectFit="cover"
+                />
+              </div>
+              <div className="p-6 md:w-1/2 flex flex-col justify-start">
+                <h3
+                  className={`${poppins.className} text-2xl font-semibold mb-2 line-clamp-3`}
+                >
+                  {beritaUtama.title}
+                </h3>
+                <p className={`${poppins.className} text-gray-500 mb-4`}>
+                  {new Date(beritaUtama.createdAt).toLocaleDateString("id-ID", {
+                    year: "numeric",
+                    month: "long",
+                    day: "numeric",
+                  })}
+                </p>
+                <p
+                  className={`${poppins.className} text-gray-600 line-clamp-6 flex-grow`}
+                >
+                  {beritaUtama.content}
+                </p>
+                <div className="mt-4">
+                  <Link href={`/berita/${beritaUtama.id}`}>
+                    <button className="bg-[#0B4973] text-white rounded px-4 py-2 font-semibold hover:bg-[#09395a] transition">
+                      Baca Selengkapnya
+                    </button>
+                  </Link>
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Berita Lainnya */}
+        {beritaLainnya.length > 0 && (
+          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-8 justify-items-center">
+            {beritaLainnya.map((item) => (
+              <Card
+                key={item.id}
+                id={item.id}
+                title={item.title}
+                content={item.content}
+                imageUrl={item.imageUrl}
+                createdAt={item.createdAt}
+              />
+            ))}
+          </div>
+        )}
+
+        {/* Pagination */}
+        {totalPages > 1 && (
+          <div className="flex justify-center items-center mt-12 space-x-2">
+            <button
+              onClick={() => handlePageChange(currentPage - 1)}
+              disabled={currentPage === 1}
+              className="px-4 py-2 bg-white border rounded-md disabled:opacity-50"
+            >
+              Sebelumnya
+            </button>
+            {Array.from({ length: totalPages }, (_, i) => i + 1).map((page) => (
+              <button
+                key={page}
+                onClick={() => handlePageChange(page)}
+                className={`px-4 py-2 border rounded-md ${
+                  currentPage === page ? "bg-[#0B4973] text-white" : "bg-white"
+                }`}
+              >
+                {page}
+              </button>
+            ))}
+            <button
+              onClick={() => handlePageChange(currentPage + 1)}
+              disabled={currentPage === totalPages}
+              className="px-4 py-2 bg-white border rounded-md disabled:opacity-50"
+            >
+              Berikutnya
+            </button>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/features/berita/card.tsx
+++ b/src/features/berita/card.tsx
@@ -1,0 +1,56 @@
+// src/features/berita/card.tsx
+
+import Image from "next/image";
+import Link from "next/link";
+import { Poppins } from "next/font/google";
+
+const poppins = Poppins({
+  subsets: ["latin"],
+  weight: ["400", "600"],
+});
+
+interface CardProps {
+  id: string;
+  title: string;
+  content: string;
+  imageUrl: string;
+  createdAt: number;
+}
+
+export default function Card({
+  id,
+  title,
+  content,
+  imageUrl,
+  createdAt,
+}: CardProps) {
+  return (
+    <div
+      className={`${poppins.className} bg-white rounded-xl shadow-md overflow-hidden w-full max-w-xs flex flex-col transition-transform mb-6 h-full`}
+    >
+      <div className="relative w-full h-40">
+        <Image src={imageUrl} alt={title} fill className="object-cover" />
+      </div>
+      <div className="p-4 flex flex-col flex-grow">
+        <h3 className="text-md font-semibold mb-2 line-clamp-2 ">{title}</h3>
+        <p className="text-xs text-gray-500 mb-2">
+          {new Date(createdAt).toLocaleDateString("id-ID", {
+            year: "numeric",
+            month: "long",
+            day: "numeric",
+          })}
+        </p>
+        <p className="text-sm text-gray-600 mb-4 h-16 line-clamp-4 flex-grow ">
+          {content}
+        </p>
+        <div className="mt-auto">
+          <Link href={`/berita/${id}`}>
+            <button className="bg-[#0B4973] text-white rounded px-4 py-2 text-sm font-semibold hover:bg-[#09395a] transition w-full">
+              Baca Selengkapnya
+            </button>
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/berita/desc.tsx
+++ b/src/features/berita/desc.tsx
@@ -1,0 +1,46 @@
+// src/features/berita/desc.tsx
+
+import Image from "next/image";
+import { Playfair_Display, Poppins } from "next/font/google";
+
+const playfair = Playfair_Display({
+  subsets: ["latin"],
+  weight: ["500", "700"],
+});
+
+const poppins = Poppins({
+  subsets: ["latin"],
+  weight: ["100", "400", "700"],
+});
+
+export default function DescBerita() {
+  return (
+    <div className="w-full bg-pattern px-5 py-10 relative flex justify-center  ">
+      <Image
+        src="/Patterns.png"
+        alt="pattern"
+        fill
+        quality={80}
+        className="z-0 object-cover"
+        priority
+      />
+      <div className="max-w-6xl  flex flex-col md:flex-row gap-0  ">
+        <div className="md:w-1/2  flex items-center z-50 ">
+          <h2
+            className={`${playfair.className} text-white text-2xl md:text-4xl font-normal tracking-[1.5px] mb-4`}
+          >
+            Berita Desa
+          </h2>
+        </div>
+        <div className="md:w-1/2 flex items-center ">
+          <p
+            className={`${poppins.className} text-white text-sm md:text-lg font-normal tracking-wider whitespace-pre-line`}
+          >
+            Berikut adalah kumpulan berita dan informasi terbaru dari Desa
+            Slamparejo.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/berita/hero.tsx
+++ b/src/features/berita/hero.tsx
@@ -1,0 +1,49 @@
+// src/features/berita/hero.tsx
+
+import Image from "next/image";
+import { Playfair_Display, Poppins } from "next/font/google";
+import { BeritaPageData } from "@/lib/types";
+
+const playfair = Playfair_Display({
+  subsets: ["latin"],
+  weight: ["500", "700"],
+});
+
+const poppins = Poppins({
+  subsets: ["latin"],
+  weight: ["100", "400", "700"],
+});
+
+export default function HeroBerita({ data }: { data: BeritaPageData["hero"] }) {
+  return (
+    <section className="w-full h-screen flex flex-col ">
+      <div className="w-full bg-pattern px-5 py-10 relative flex justify-center min-h-screen">
+        <Image
+          src={data.heroImage || "/landing-page.png"}
+          alt="Desa Slamparejo"
+          fill
+          quality={100}
+          className="z-0 object-cover "
+          priority
+          sizes="100vw"
+        />
+        <div className="absolute inset-0  bg-black/40 z-10" />
+        <div className="relative z-20 flex flex-col items-center justify-center h-full text-center px-4">
+          <div className="relative flex flex-col items-center w-fit mx-auto mb-6">
+            <h1
+              className={`${playfair.className} text-white text-4xl md:text-6xl tracking-[9px]`}
+            >
+              {data.title}
+            </h1>
+            <div className="w-full border-b-1 border-white rounded-b-lg mt-6" />
+          </div>
+          <p
+            className={`${poppins.className} text-white text-lg md:text-2xl font-thin leading-8  md:leading-10 max-w-2xl mb-10 w-full`}
+          >
+            {data.subtitle}
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/features/navbar.tsx
+++ b/src/features/navbar.tsx
@@ -27,12 +27,13 @@ const poppins = Poppins({
 
 const dataNav = [
   { id: 0, name: "BERANDA", href: "/" },
-  { id: 1, name: "PROFIL", href: "/profil" },
-  { id: 2, name: "LAYANAN", href: "/layanan" },
-  { id: 3, name: "USAHA DESA", href: "/usaha-desa" },
-  { id: 4, name: "PERANGKAT DESA", href: "/perangkat-desa" },
-  { id: 5, name: "KONTAK", href: "/kontak" },
-  { id: 6, name: "PRODUK", href: "/produk-hukum-dan-fisik" },
+  { id: 1, name: "BERITA", href: "/berita" },
+  { id: 2, name: "PROFIL", href: "/profil" },
+  { id: 3, name: "LAYANAN", href: "/layanan" },
+  { id: 4, name: "USAHA DESA", href: "/usaha-desa" },
+  { id: 5, name: "PERANGKAT DESA", href: "/perangkat-desa" },
+  { id: 6, name: "KONTAK", href: "/kontak" },
+  { id: 7, name: "PRODUK", href: "/produk-hukum-dan-fisik" },
 ];
 
 export default function Navbar() {
@@ -64,7 +65,6 @@ export default function Navbar() {
           </div>
         </Link>
 
-        {/* Desktop Navigation */}
         <nav className="hidden md:flex gap-8">
           {dataNav.map((data) => (
             <Link

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,3 +1,5 @@
+// src/lib/types.ts
+
 export interface Usaha {
   id: string;
   image: string;
@@ -164,4 +166,21 @@ export interface UsahaDesaPageData {
     heroImage?: string;
   };
   description: string;
+}
+
+export interface Berita {
+  id: string;
+  title: string;
+  content: string;
+  imageUrl: string;
+  createdAt: number;
+  isHeadline?: boolean;
+}
+
+export interface BeritaPageData {
+  hero: {
+    title: string;
+    subtitle: string;
+    heroImage?: string;
+  };
 }


### PR DESCRIPTION
- Introduced a new "Berita" section in the admin dashboard for managing news articles.
- Created API routes for fetching, creating, updating, and deleting news articles.
- Implemented a detail page for individual news articles.
- Developed a main news page that displays a list of articles with pagination.
- Added components for displaying news articles, including a hero section and a description.
- Integrated Cloudinary for image uploads in news articles.
- Updated type definitions to include news article data structures.